### PR TITLE
Rust 1.33: mask some deprecation warnings and use .transpose()

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ Configuration should follow the format described in `example_config.json`; the d
 `/etc/duo-auth-rs.json`.
 
 This software is licensed under the ISC license, a copy of which can be found in the file [LICENSE.txt](LICENSE.txt).
+
+This tool requires Rust 1.33 or later.

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,19 +62,13 @@ impl Config {
     }
 
     pub(crate) fn make_recent_ip(&self) -> Result<Option<RecentIp>> {
-        match self.recent_ip_file.as_ref().map(|path| {
+        self.recent_ip_file.as_ref().map(|path| {
             RecentIp::try_new(
                 path,
                 self.recent_ip_duration,
                 self.mask_ipv6
             )
-        }) {
-            // the transpose function in 1.33 will save me from this
-            None => Ok(None),
-            Some(Ok(val)) => Ok(Some(val)),
-            Some(Err(db_error)) => Err(db_error.into())
-        }
-
+        }).transpose().map_err(Error::from)
     }
 }
 

--- a/src/duo_client.rs
+++ b/src/duo_client.rs
@@ -10,6 +10,7 @@ use hex;
 
 use crate::config;
 
+#[allow(deprecated)]
 pub(crate) mod errors {
     use crate::duo_client::DuoResponseStatus;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod duo_client;
 mod recent_ip;
 mod ip_whitelist;
 
+#[allow(deprecated)]
 mod errors {
     error_chain!{
         links {

--- a/src/recent_ip.rs
+++ b/src/recent_ip.rs
@@ -6,6 +6,7 @@ use rusqlite::{self, NO_PARAMS};
 use rusqlite::types::ToSql;
 
 
+#[allow(deprecated)]
 pub(crate) mod errors {
     error_chain! {
         types {


### PR DESCRIPTION
This uses the new `transpose` method in Rust 1.33 and masks error from error-chain (see rust-lang-nursery/error-chain#254)