### PR TITLE
bump to reqwest 0.11 (and tokio 1.0); also bump other dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ license = "ISC"
 edition = "2018"
 
 [dependencies]
-reqwest = { version = "0.10", features = ["blocking", "json"] }
+reqwest = { version = "0.11", features = ["blocking", "json"] }
 chrono = "^0.4"
-sha-1 = "0.8"
-hmac = "0.7"
+sha-1 = "0.9"
+hmac = "0.10"
 clap = "2"
 log = "^0.4"
 hex = "^0.3.2"
@@ -21,7 +21,7 @@ serde_json = "1.0"
 log-panics = { version = "1.1" , features = ["with-backtrace"] }
 thiserror = "1.0"
 url = "2"
-ipnetwork = "^0.16"
+ipnetwork = "^0.17"
 syslog = "^5.0"
 rusqlite = { version = "^0.24", features = ["bundled"] }
 

--- a/src/duo_client.rs
+++ b/src/duo_client.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use chrono::{DateTime, Utc};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, Mac, NewMac};
 use log::warn;
 use reqwest::{self, Method, Url};
 use serde_json::Value;
@@ -146,8 +146,8 @@ impl<'a> DuoRequest<'a> {
         let to_sign = to_sign.join("\n");
         let mut signer =
             HmacSha1::new_varkey(&client.skey.as_bytes()).expect("skey must be the right size");
-        signer.input(to_sign.as_bytes());
-        hex::encode(signer.result().code())
+        signer.update(to_sign.as_bytes());
+        hex::encode(signer.finalize().into_bytes())
     }
 
     fn run(self, client: &DuoClient) -> Result<DuoResponse> {


### PR DESCRIPTION
There are no no warnings from `cargo audit`