### PR TITLE
modernize a bunch of duo-auth-rs dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,14 @@ jobs:
         toolchain: stable
         components: rustfmt
         default: true
-    - name: install cargo audit
-      uses: actions-rs/cargo@v1
+    - name: Install cargo-audit binary crate
+      uses: actions-rs/install@v0.1
       with:
-        command: install --force cargo-audit
+        crate: cargo-audit
+        version: latest
+        use-tool-cache: true
     - name: cargo audit
       uses: actions-rs/cargo@v1
       with:
-        command: audit --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071
+        command: audit
+        args: --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,11 @@ jobs:
         toolchain: stable
         components: rustfmt
         default: true
-    - name: cargo audit
-      uses: actions-rs/audit-check@v1.2.0
+    - name: install cargo audit
+      uses: actions-rs/cargo@v1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        command: install --force cargo-audit
+    - name: cargo audit
+      uses: actions-rs/cargo@v1
+      with:
+        command: audit --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ hmac = "0.12"
 clap = "3"
 log = "^0.4"
 hex = "^0.4.3"
-env_logger = "^0.7"
+env_logger = "^0.9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 log-panics = { version = "2" , features = ["with-backtrace"] }
 thiserror = "1"
 url = "2"
-ipnetwork = "^0.16"
+ipnetwork = "^0.18"
 syslog = "^5.0"
 rusqlite = { version = "^0.26", features = ["bundled"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,24 +7,22 @@ license = "ISC"
 edition = "2018"
 
 [dependencies]
-reqwest = { version = "0.10", features = ["blocking", "json"] }
+reqwest = { version = "0.11", features = ["blocking", "json"] }
 chrono = "^0.4"
-sha-1 = "0.8"
-hmac = "0.7"
-clap = "2"
+sha-1 = "0.10"
+hmac = "0.12"
+clap = "3"
 log = "^0.4"
-hex = "^0.3.2"
+hex = "^0.4.3"
 env_logger = "^0.7"
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
-log-panics = { version = "1.1" , features = ["with-backtrace"] }
-thiserror = "1.0"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+log-panics = { version = "2" , features = ["with-backtrace"] }
+thiserror = "1"
 url = "2"
 ipnetwork = "^0.16"
 syslog = "^5.0"
-rusqlite = { version = "^0.24", features = ["bundled"] }
+rusqlite = { version = "^0.26", features = ["bundled"] }
 
 [dev-dependencies]
-tempfile = "3.0"
-
+tempfile = "3.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 use super::{Error, Result};
 use crate::ip_whitelist::IpWhitelist;
@@ -54,7 +54,7 @@ impl Config {
     pub fn from_path(p: &Path) -> Result<Self> {
         let f = File::open(p).map_err(Error::ConfigIOError)?;
         let config: RawConfig = serde_json::from_reader(f)?;
-        Ok(Config::from_raw_config(config)?)
+        Config::from_raw_config(config)
     }
 
     pub(crate) fn make_recent_ip(&self) -> Result<Option<RecentIp>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,15 +46,15 @@ fn main_r() -> Result<i32> {
         .about(env!("CARGO_PKG_DESCRIPTION"))
         .author("James Brown <jbrown@easypost.com>")
         .arg(
-            Arg::with_name("stderr")
-                .short("e")
+            Arg::new("stderr")
+                .short('e')
                 .long("stderr")
                 .takes_value(false)
                 .help("Log to stderr instead of syslog"),
         )
         .arg(
-            Arg::with_name("config_file")
-                .short("c")
+            Arg::new("config_file")
+                .short('c')
                 .long("config-file")
                 .takes_value(true)
                 .value_name("PATH")
@@ -62,7 +62,7 @@ fn main_r() -> Result<i32> {
                 .help("Path to config file"),
         )
         .arg(
-            Arg::with_name("username_env")
+            Arg::new("username_env")
                 .long("username-env")
                 .takes_value(true)
                 .value_name("VAR")
@@ -70,7 +70,7 @@ fn main_r() -> Result<i32> {
                 .help("Name of environment variable containing username"),
         )
         .arg(
-            Arg::with_name("ip_env")
+            Arg::new("ip_env")
                 .long("ip-env")
                 .takes_value(true)
                 .value_name("VAR")
@@ -78,13 +78,13 @@ fn main_r() -> Result<i32> {
                 .help("Name of environment variable containing remote IP"),
         )
         .arg(
-            Arg::with_name("check")
+            Arg::new("check")
                 .long("check-duo")
                 .takes_value(false)
                 .help("Run check method on Duo before authing"),
         )
         .arg(
-            Arg::with_name("never_duo")
+            Arg::new("never_duo")
                 .long("never-duo")
                 .takes_value(false)
                 .help("If passed, will never call Duo and will just fail of no whitelists match"),

--- a/src/recent_ip.rs
+++ b/src/recent_ip.rs
@@ -4,7 +4,6 @@ use std::time::{Duration, UNIX_EPOCH};
 
 use log::{debug, error, warn};
 use rusqlite::types::ToSql;
-use rusqlite::{self, NO_PARAMS};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -28,7 +27,7 @@ fn now() -> i64 {
     duration.as_secs() as i64
 }
 
-// Fun fact: the to_ipv5() method on Ipv6Addr now accepts IPv4-compatible addresses,
+// Fun fact: the to_ipv6() method on Ipv6Addr now accepts IPv4-compatible addresses,
 // which are impossible to distinguish from loopback addresses
 trait IsIpv4Mapped {
     fn is_ipv4_mapped(&self) -> bool;
@@ -51,7 +50,7 @@ impl RecentIp {
         let mut conn = rusqlite::Connection::open(path)?;
         {
             let xact = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
-            xact.execute("CREATE TABLE IF NOT EXISTS logins (user STRING NOT NULL, rhost STRING NOT NULL, last_success_at INTEGER, UNIQUE (user, rhost));", NO_PARAMS)?;
+            xact.execute("CREATE TABLE IF NOT EXISTS logins (user STRING NOT NULL, rhost STRING NOT NULL, last_success_at INTEGER, UNIQUE (user, rhost));", [])?;
             xact.commit()?;
         }
         Ok(Self {


### PR DESCRIPTION
no actual changes, just version bumps.

audit check will fail because there's still no way to avoid `time` / `chrono`